### PR TITLE
Fix sentiment library usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
         function main() {
             logToScreen('App Initialized. DOM and scripts loaded.');
 
-            const sentiment = new SentimentIntensityAnalyzer();
+            const sentiment = SentimentIntensityAnalyzer;
             let positiveStoryCache = [];
 
             // Load API keys from local storage on page load


### PR DESCRIPTION
## Summary
- use the `SentimentIntensityAnalyzer` class directly instead of creating an instance

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6842f47021b4832f84196c81cbe78c81